### PR TITLE
Enable and use org level Discussions tab

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question
-    url: https://github.com/YOURLS/YOURLS/discussions
+    url: https://github.com/orgs/YOURLS/discussions
     about: 🙏 Ask questions and discuss with other community members


### PR DESCRIPTION
See the freshly released docs about this feature: https://docs.github.com/en/discussions/quickstart#enabling-github-discussions-on-your-organization

* On org: https://github.com/orgs/YOURLS/discussions
* Still on repo: https://github.com/YOURLS/YOURLS/discussions