### PR TITLE
Add an option to use Super Linter fixers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,11 @@ on:
         default: ""
         type: string
         description: Regex filter of path to exclude
+      fix:
+        required: false
+        default: false
+        type: boolean
+        description: Fix linting and formatting issues
 
 permissions:
   contents: read
@@ -42,3 +47,12 @@ jobs:
           VALIDATE_JSCPD: false
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+          FIX_CSS: ${{ inputs.fix }}
+          FIX_JSON: ${{ inputs.fix }}
+          FIX_JSONC: ${{ inputs.fix }}
+          FIX_MARKDOWN: ${{ inputs.fix }}
+          FIX_NATURAL_LANGUAGE: ${{ inputs.fix }}
+          FIX_TSX: ${{ inputs.fix }}
+          FIX_JAVASCRIPT_PRETTIER: ${{ inputs.fix }}
+          FIX_TYPESCRIPT_PRETTIER: ${{ inputs.fix }}
+          FIX_YAML_PRETTIER: ${{ inputs.fix }}


### PR DESCRIPTION
## Pre-requisites

- [x] I have read the [Contributing Guidelines](https://github.com/YOURLS/.github/blob/main/CONTRIBUTING.md)
- [ ] I am using AI and have read the [AI Policy](https://github.com/YOURLS/.github/blob/main/AI_POLICY.md)


## Change Description

Add an option to use Super Linter fixers.
This is a follow-up on @dgw' suggestion on reducing linter burden.
The option will be enabled on the website repo, via https://github.com/YOURLS/website/pull/452.